### PR TITLE
Implementation WriteEventRepository + Automatic PlayOfferCancellation on Club/Member lock/delete event

### DIFF
--- a/Application/Handlers/CancelPlayOfferHandler.cs
+++ b/Application/Handlers/CancelPlayOfferHandler.cs
@@ -11,13 +11,13 @@ namespace PlayOfferService.Application.Handlers;
 
 public class CancelPlayOfferHandler : IRequestHandler<CancelPlayOfferCommand, Task>
 {
-    private readonly DbWriteContext _context;
+    private readonly WriteEventRepository _writeEventRepository;
     private readonly PlayOfferRepository _playOfferRepository;
     private readonly ClubRepository _clubRepository;
     
-    public CancelPlayOfferHandler(DbWriteContext context, PlayOfferRepository playOfferRepository, ClubRepository clubRepository)
+    public CancelPlayOfferHandler(WriteEventRepository writeEventRepository, PlayOfferRepository playOfferRepository, ClubRepository clubRepository)
     {
-        _context = context;
+        _writeEventRepository = writeEventRepository;
         _playOfferRepository = playOfferRepository;
         _clubRepository = clubRepository;
     }
@@ -55,8 +55,8 @@ public class CancelPlayOfferHandler : IRequestHandler<CancelPlayOfferCommand, Ta
             Timestamp = DateTime.UtcNow
         };
         
-        _context.Events.Add(domainEvent);
-        await _context.SaveChangesAsync();
+        await _writeEventRepository.AppendEvent(domainEvent);
+        await _writeEventRepository.Update();
         
         return Task.CompletedTask;
     }

--- a/Application/Handlers/CreatePlayOfferHandler.cs
+++ b/Application/Handlers/CreatePlayOfferHandler.cs
@@ -10,13 +10,13 @@ namespace PlayOfferService.Application.Handlers;
 public class CreatePlayOfferHandler : IRequestHandler<CreatePlayOfferCommand, Guid>
 {
 
-    private readonly DbWriteContext _context;
+    private readonly WriteEventRepository _writeEventRepository;
     private readonly ClubRepository _clubRepository;
     private readonly MemberRepository _memberRepository;
 
-    public CreatePlayOfferHandler(DbWriteContext context, ClubRepository clubRepository, MemberRepository memberRepository)
+    public CreatePlayOfferHandler(WriteEventRepository writeEventRepository, ClubRepository clubRepository, MemberRepository memberRepository)
     {
-        _context = context;
+        _writeEventRepository = writeEventRepository;
         _clubRepository = clubRepository;
         _memberRepository = memberRepository;
     }
@@ -65,8 +65,8 @@ public class CreatePlayOfferHandler : IRequestHandler<CreatePlayOfferCommand, Gu
             Timestamp = DateTime.Now.ToUniversalTime()
         };
 
-        _context.Events.Add(domainEvent);
-        await _context.SaveChangesAsync();
+        await _writeEventRepository.AppendEvent(domainEvent);
+        await _writeEventRepository.Update();
 
         return playOfferId;
     }

--- a/Application/Handlers/JoinPlayOfferHandler.cs
+++ b/Application/Handlers/JoinPlayOfferHandler.cs
@@ -11,14 +11,14 @@ namespace PlayOfferService.Application.Handlers;
 
 public class JoinPlayOfferHandler : IRequestHandler<JoinPlayOfferCommand, Task>
 {
-    private readonly DbWriteContext _context;
+    private readonly WriteEventRepository _writeEventRepository;
     private readonly PlayOfferRepository _playOfferRepository;
     private readonly MemberRepository _memberRepository;
     private readonly ClubRepository _clubRepository;
 
-    public JoinPlayOfferHandler(DbWriteContext context, PlayOfferRepository playOfferRepository, MemberRepository memberRepository, ClubRepository clubRepository)
+    public JoinPlayOfferHandler(WriteEventRepository writeEventRepository, PlayOfferRepository playOfferRepository, MemberRepository memberRepository, ClubRepository clubRepository)
     {
-        _context = context;
+        _writeEventRepository = writeEventRepository;
         _playOfferRepository = playOfferRepository;
         _memberRepository = memberRepository;
         _clubRepository = clubRepository;
@@ -79,8 +79,8 @@ public class JoinPlayOfferHandler : IRequestHandler<JoinPlayOfferCommand, Task>
             Timestamp = DateTime.UtcNow
         };
 
-        _context.Events.Add(domainEvent);
-        await _context.SaveChangesAsync();
+        await _writeEventRepository.AppendEvent(domainEvent);
+        await _writeEventRepository.Update();
 
         return Task.CompletedTask;
     }

--- a/Domain/Repositories/WriteEventRepository.cs
+++ b/Domain/Repositories/WriteEventRepository.cs
@@ -26,6 +26,15 @@ public class WriteEventRepository
         return events.First();
     }
     
+    public virtual async Task<List<BaseEvent>> GetEventByEntityId(Guid entityId)
+    {
+        var events = await _context.Events
+            .Where(e => e.EntityId == entityId)
+            .ToListAsync();
+
+        return events;
+    }
+    
     public virtual async Task AppendEvent(BaseEvent baseEvent)
     {
         _context.Events.Add(baseEvent);

--- a/Domain/Repositories/WriteEventRepository.cs
+++ b/Domain/Repositories/WriteEventRepository.cs
@@ -3,20 +3,20 @@ using PlayOfferService.Domain.Events;
 
 namespace PlayOfferService.Domain.Repositories;
 
-public class ReadEventRepository
+public class WriteEventRepository
 {
-    private readonly DbReadContext _context;
+    private readonly DbWriteContext _context;
     
-    public ReadEventRepository(){}
+    public WriteEventRepository(){}
     
-    public ReadEventRepository(DbReadContext context)
+    public WriteEventRepository(DbWriteContext context)
     {
         _context = context;
     }
     
     public virtual async Task<BaseEvent?> GetEventById(Guid eventId)
     {
-        var events = await _context.AppliedEvents
+        var events = await _context.Events
             .Where(e => e.EventId == eventId)
             .ToListAsync();
 
@@ -28,7 +28,7 @@ public class ReadEventRepository
     
     public virtual async Task AppendEvent(BaseEvent baseEvent)
     {
-        _context.AppliedEvents.Add(baseEvent);
+        _context.Events.Add(baseEvent);
     }
     
     public virtual async Task Update()

--- a/PlayOfferService.Tests/IntegrationTests/ClubEventHandlerTest.cs
+++ b/PlayOfferService.Tests/IntegrationTests/ClubEventHandlerTest.cs
@@ -9,13 +9,54 @@ public class ClubEventHandlerTest : TestSetup
     [SetUp]
     public async Task ClubSetup()
     {
-        var existingClub = new Club
+        var existingClubs = new List<Club>
         {
-            Id = Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa"),
-            Status = Status.ACTIVE
+            new()
+            {
+                Id = Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa"),
+                Status = Status.ACTIVE
+            },
+            new()
+            {
+                Id = Guid.Parse("2db387f0-5792-4cb5-91a6-6317437b3432"),
+                Status = Status.ACTIVE
+            }
         };
-        TestClubRepository.CreateClub(existingClub);
+        
+        foreach (var club in existingClubs)
+        {
+            TestClubRepository.CreateClub(club);
+        }
         await TestClubRepository.Update();
+        
+        var existingPlayOffers = new List<PlayOffer>
+        {
+            new()
+            {
+                Id = Guid.Parse("d9afd6dd-8836-47dd-86be-3467a7db0fe5"),
+                ClubId = Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa"),
+                CreatorId = Guid.Parse("4f5d3d99-1b8e-4276-8eff-32d484eef56c"),
+                ProposedStartTime = DateTime.UtcNow,
+                ProposedEndTime = DateTime.UtcNow.AddHours(3),
+                IsCancelled = false
+            },
+            new()
+            {
+                Id = Guid.Parse("9ee6d9d7-d4a6-4904-a20b-be026de53c4f"),
+                ClubId = Guid.Parse("2db387f0-5792-4cb5-91a6-6317437b3432"),
+                CreatorId = Guid.Parse("c18e24c1-21bf-4505-ae15-e1960c0f7a9b"),
+                ProposedStartTime = DateTime.UtcNow,
+                ProposedEndTime = DateTime.UtcNow.AddHours(3),
+                IsCancelled = false
+            },
+        };
+        
+        foreach (var playOffer in existingPlayOffers)
+        {
+            TestPlayOfferRepository.CreatePlayOffer(playOffer);
+        }
+        
+        await TestPlayOfferRepository.Update();
     }
     
     [Test]
@@ -57,7 +98,7 @@ public class ClubEventHandlerTest : TestSetup
         {
             EntityId = Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa"),
             EntityType = EntityType.TENNIS_CLUB,
-            EventId = Guid.NewGuid(),
+            EventId = Guid.Parse("ee90c3ee-3b4b-4ccb-8933-739795a7253a"),
             EventType = EventType.TENNIS_CLUB_LOCKED,
             EventData = new ClubLockedEvent()
         };
@@ -73,6 +114,16 @@ public class ClubEventHandlerTest : TestSetup
         {
             Assert.That(projectedClub!.Id, Is.EqualTo(Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa")));
             Assert.That(projectedClub.Status, Is.EqualTo(Status.LOCKED));
+        });
+        
+        var playOfferEvents = await TestWriteEventRepository.GetEventByEntityId(Guid.Parse("d9afd6dd-8836-47dd-86be-3467a7db0fe5"));
+        Assert.That(playOfferEvents, Has.Count.EqualTo(1));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(playOfferEvents.First().EntityId, Is.EqualTo(Guid.Parse("d9afd6dd-8836-47dd-86be-3467a7db0fe5")));
+            Assert.That(playOfferEvents.First().EventType, Is.EqualTo(EventType.PLAYOFFER_CANCELLED));
+            Assert.That(playOfferEvents.First().CorrelationId, Is.EqualTo(Guid.Parse("ee90c3ee-3b4b-4ccb-8933-739795a7253a")));
         });
     }
     
@@ -109,9 +160,9 @@ public class ClubEventHandlerTest : TestSetup
         //Given
         var clubDeletedEvent = new TechnicalClubEvent
         {
-            EntityId = Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa"),
+            EntityId = Guid.Parse("2db387f0-5792-4cb5-91a6-6317437b3432"),
             EntityType = EntityType.TENNIS_CLUB,
-            EventId = Guid.NewGuid(),
+            EventId = Guid.Parse("ab0ecc19-e492-4126-aac5-5448198d62cc"),
             EventType = EventType.TENNIS_CLUB_DELETED,
             EventData = new ClubDeletedEvent()
         };
@@ -120,13 +171,23 @@ public class ClubEventHandlerTest : TestSetup
         await Mediator.Send(clubDeletedEvent);
 
         //Then
-        var projectedClub = await TestClubRepository.GetClubById(Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa"));
+        var projectedClub = await TestClubRepository.GetClubById(Guid.Parse("2db387f0-5792-4cb5-91a6-6317437b3432"));
 
         Assert.That(projectedClub, Is.Not.Null);
         Assert.Multiple(() =>
         {
-            Assert.That(projectedClub!.Id, Is.EqualTo(Guid.Parse("8aa54411-32fe-4b4c-a017-aa9710cb3bfa")));
+            Assert.That(projectedClub!.Id, Is.EqualTo(Guid.Parse("2db387f0-5792-4cb5-91a6-6317437b3432")));
             Assert.That(projectedClub.Status, Is.EqualTo(Status.DELETED));
+        });
+        
+        var playOfferEvents = await TestWriteEventRepository.GetEventByEntityId(Guid.Parse("9ee6d9d7-d4a6-4904-a20b-be026de53c4f"));
+        Assert.That(playOfferEvents, Has.Count.EqualTo(1));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(playOfferEvents.First().EntityId, Is.EqualTo(Guid.Parse("9ee6d9d7-d4a6-4904-a20b-be026de53c4f")));
+            Assert.That(playOfferEvents.First().EventType, Is.EqualTo(EventType.PLAYOFFER_CANCELLED));
+            Assert.That(playOfferEvents.First().CorrelationId, Is.EqualTo(Guid.Parse("ab0ecc19-e492-4126-aac5-5448198d62cc")));
         });
     }
 }

--- a/PlayOfferService.Tests/IntegrationTests/MemberEventHandlerTest.cs
+++ b/PlayOfferService.Tests/IntegrationTests/MemberEventHandlerTest.cs
@@ -10,14 +10,56 @@ public class MemberEventHandlerTest : TestSetup
     [SetUp]
     public async Task MemberSetup()
     {
-        var existingMember = new Member
+        var existingMembers = new List<Member>
         {
-            Id = Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"),
-            ClubId = Guid.Parse("bf7f59db-e2bf-4a4f-95fe-baeabe948b81"),
-            Status = Status.ACTIVE
+            new()
+            {
+                Id = Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"),
+                ClubId = Guid.Parse("bf7f59db-e2bf-4a4f-95fe-baeabe948b81"),
+                Status = Status.ACTIVE
+            },
+            new()
+            {
+                Id = Guid.Parse("c559d8ad-67be-4739-afb0-94460d7bb100"),
+                ClubId = Guid.Parse("8ad9ddaa-8ce6-4655-b2da-fb3419f93a67"),
+                Status = Status.ACTIVE
+            }
         };
-        TestMemberRepository.CreateMember(existingMember);
+        
+        foreach (var member in existingMembers)
+        {
+            TestMemberRepository.CreateMember(member);
+        }
         await TestMemberRepository.Update();
+
+        var existingPlayOffers = new List<PlayOffer>
+        {
+            new()
+            {
+                Id = Guid.Parse("033cad0e-6270-487c-85e2-02a7b531b1cd"),
+                ClubId = Guid.Parse("c7545dea-2b37-4ee9-b99b-7ee422565870"),
+                CreatorId = Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"),
+                ProposedStartTime = DateTime.UtcNow,
+                ProposedEndTime = DateTime.UtcNow.AddHours(3),
+                IsCancelled = false
+            },
+            new()
+            {
+                Id = Guid.Parse("301289c5-6789-4a64-b9f6-37a141191123"),
+                ClubId = Guid.Parse("7b219549-58fb-4018-8958-151eacab2d1c"),
+                CreatorId = Guid.Parse("c559d8ad-67be-4739-afb0-94460d7bb100"),
+                ProposedStartTime = DateTime.UtcNow,
+                ProposedEndTime = DateTime.UtcNow.AddHours(3),
+                IsCancelled = false
+            },
+        };
+        
+        foreach (var playOffer in existingPlayOffers)
+        {
+            TestPlayOfferRepository.CreatePlayOffer(playOffer);
+        }
+        
+        await TestPlayOfferRepository.Update();
     }
     
     [Test]
@@ -57,12 +99,11 @@ public class MemberEventHandlerTest : TestSetup
     public async Task MemberLockEvent_ProjectionTest()
     {
         //Given
-        var existingMember = await TestMemberRepository.GetMemberById(Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"));
         var memberLockEvent = new TechnicalMemberEvent
         {
-            EntityId = existingMember!.Id,
+            EntityId = Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"),
             EntityType = EntityType.MEMBER,
-            EventId = Guid.NewGuid(),
+            EventId = Guid.Parse("d1f2c32e-77b3-4e3b-a632-7ea710e93b44"),
             EventType = EventType.MEMBER_LOCKED,
             EventData = new MemberLockedEvent()
         };
@@ -71,13 +112,22 @@ public class MemberEventHandlerTest : TestSetup
         await Mediator.Send(memberLockEvent);
         
         //Then
-        var projectedMember = await TestMemberRepository.GetMemberById(existingMember.Id);
-        
+        var projectedMember = await TestMemberRepository.GetMemberById(Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"));
         Assert.That(projectedMember, Is.Not.Null);
         Assert.Multiple(() =>
         {
-            Assert.That(projectedMember!.Id, Is.EqualTo(existingMember.Id));
+            Assert.That(projectedMember!.Id, Is.EqualTo(Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b")));
             Assert.That(projectedMember.Status, Is.EqualTo(Status.LOCKED));
+        });
+        
+        var playOfferEvents = await TestWriteEventRepository.GetEventByEntityId(Guid.Parse("033cad0e-6270-487c-85e2-02a7b531b1cd"));
+        Assert.That(playOfferEvents, Has.Count.EqualTo(1));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(playOfferEvents.First().EntityId, Is.EqualTo(Guid.Parse("033cad0e-6270-487c-85e2-02a7b531b1cd")));
+            Assert.That(playOfferEvents.First().EventType, Is.EqualTo(EventType.PLAYOFFER_CANCELLED));
+            Assert.That(playOfferEvents.First().CorrelationId, Is.EqualTo(Guid.Parse("d1f2c32e-77b3-4e3b-a632-7ea710e93b44")));
         });
     }
     
@@ -113,12 +163,11 @@ public class MemberEventHandlerTest : TestSetup
     public async Task MemberDeletedEvent_ProjectionTest()
     {
         //Given
-        var existingMember = await TestMemberRepository.GetMemberById(Guid.Parse("971c48ff-42f4-4dc5-94ad-42e3c155b07b"));
         var memberDeleteEvent = new TechnicalMemberEvent
         {
-            EntityId = existingMember!.Id,
+            EntityId = Guid.Parse("c559d8ad-67be-4739-afb0-94460d7bb100"),
             EntityType = EntityType.MEMBER,
-            EventId = Guid.NewGuid(),
+            EventId = Guid.Parse("367d90df-ef2e-44cf-a6e1-704fbafbb561"),
             EventType = EventType.MEMBER_DELETED,
             EventData = new MemberDeletedEvent()
         };
@@ -127,13 +176,23 @@ public class MemberEventHandlerTest : TestSetup
         await Mediator.Send(memberDeleteEvent);
         
         //Then
-        var projectedMember = await TestMemberRepository.GetMemberById(existingMember.Id);
+        var projectedMember = await TestMemberRepository.GetMemberById(Guid.Parse("c559d8ad-67be-4739-afb0-94460d7bb100"));
         
         Assert.That(projectedMember, Is.Not.Null);
         Assert.Multiple(() =>
         {
-            Assert.That(projectedMember!.Id, Is.EqualTo(existingMember.Id));
+            Assert.That(projectedMember!.Id, Is.EqualTo(Guid.Parse("c559d8ad-67be-4739-afb0-94460d7bb100")));
             Assert.That(projectedMember.Status, Is.EqualTo(Status.DELETED));
+        });
+        
+        var playOfferEvents = await TestWriteEventRepository.GetEventByEntityId(Guid.Parse("301289c5-6789-4a64-b9f6-37a141191123"));
+        Assert.That(playOfferEvents, Has.Count.EqualTo(1));
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(playOfferEvents.First().EntityId, Is.EqualTo(Guid.Parse("301289c5-6789-4a64-b9f6-37a141191123")));
+            Assert.That(playOfferEvents.First().EventType, Is.EqualTo(EventType.PLAYOFFER_CANCELLED));
+            Assert.That(playOfferEvents.First().CorrelationId, Is.EqualTo(Guid.Parse("367d90df-ef2e-44cf-a6e1-704fbafbb561")));
         });
     }
 }

--- a/PlayOfferService.Tests/IntegrationTests/ReadEventRepositoryTest.cs
+++ b/PlayOfferService.Tests/IntegrationTests/ReadEventRepositoryTest.cs
@@ -1,0 +1,112 @@
+using PlayOfferService.Domain.Events;
+using PlayOfferService.Domain.Events.Member;
+using PlayOfferService.Domain.Models;
+using PlayOfferService.Domain.ValueObjects;
+
+namespace PlayOfferService.Tests.IntegrationTests;
+
+public class ReadEventRepositoryTest : TestSetup
+{
+    [SetUp]
+    public async Task ReadEventSetup()
+    {
+        var existingEvent = new BaseEvent
+        {
+            EntityId = Guid.Parse("eca14668-95c5-4e40-8f24-7afc155b39a1"),
+            EntityType = EntityType.MEMBER,
+            EventId = Guid.Parse("1609fbee-e9e2-4485-a83b-1db7ba78f384"),
+            EventType = EventType.MEMBER_REGISTERED,
+            Timestamp = DateTime.UtcNow,
+            EventData = new MemberCreatedEvent
+            {
+                Email = "testemail@gmail.com",
+                MemberId = new MemberId { Id = Guid.Parse("3ba41c4b-2b0e-4263-b847-518869978e4d") },
+                Name = new FullName { FirstName = "Max", LastName = "Mustermann" },
+                Status = Status.ACTIVE,
+                TennisClubId = new TennisClubId { Id = Guid.Parse("9af8b30c-865c-4aa2-9590-9a81ab66d7a1") }
+            }
+        };
+        await TestReadEventRepository.AppendEvent(existingEvent);
+        await TestReadEventRepository.Update();
+    }
+
+    [Test]
+    public async Task GetExistingEventByIdTest()
+    {
+        // Given
+        var eventId = Guid.Parse("1609fbee-e9e2-4485-a83b-1db7ba78f384");
+
+        // When
+        var baseEvent = await TestReadEventRepository.GetEventById(eventId);
+
+        // Then
+        Assert.That(baseEvent, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseEvent!.EntityId, Is.EqualTo(Guid.Parse("eca14668-95c5-4e40-8f24-7afc155b39a1")));
+            Assert.That(baseEvent.EntityType, Is.EqualTo(EntityType.MEMBER));
+            Assert.That(baseEvent.EventId, Is.EqualTo(Guid.Parse("1609fbee-e9e2-4485-a83b-1db7ba78f384")));
+            Assert.That(baseEvent.EventType, Is.EqualTo(EventType.MEMBER_REGISTERED));
+            Assert.That(baseEvent.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Seconds);
+            Assert.That(baseEvent.EventData, Is.TypeOf<MemberCreatedEvent>());
+            var eventData = baseEvent.EventData as MemberCreatedEvent;
+            Assert.That(eventData!.Email, Is.EqualTo("testemail@gmail.com"));
+            Assert.That(eventData.MemberId.Id, Is.EqualTo(Guid.Parse("3ba41c4b-2b0e-4263-b847-518869978e4d")));
+            Assert.That(eventData.Name.FirstName, Is.EqualTo("Max"));
+            Assert.That(eventData.Name.LastName, Is.EqualTo("Mustermann"));
+            Assert.That(eventData.Status, Is.EqualTo(Status.ACTIVE));
+            Assert.That(eventData.TennisClubId.Id, Is.EqualTo(Guid.Parse("9af8b30c-865c-4aa2-9590-9a81ab66d7a1")));
+        });
+    }
+
+    [Test]
+    public async Task GetNonExistingEventByIdTest()
+    {
+        // Given
+        var eventId = Guid.Parse("00000000-0000-0000-0000-000000000000");
+
+        // When
+        var baseEvent = await TestReadEventRepository.GetEventById(eventId);
+
+        // Then
+        Assert.That(baseEvent, Is.Null);
+    }
+
+    [Test]
+    public async Task AppendEventTest()
+    {
+        // Given
+        var givenEvent = new BaseEvent
+        {
+            EntityId = Guid.Parse("481241b5-7435-4019-bb6d-e5bf3af4a376"),
+            EntityType = EntityType.MEMBER,
+            EventId = Guid.Parse("73b9f922-ea88-4764-9f0f-7cf132336866"),
+            EventType = EventType.MEMBER_REGISTERED,
+            Timestamp = DateTime.UtcNow,
+            EventData = new MemberCreatedEvent
+            {
+                Email = "testemail@gmail.com",
+                MemberId = new MemberId { Id = Guid.Parse("93b12459-c749-4eda-8c3d-5196946e4a25") },
+                Name = new FullName { FirstName = "Max", LastName = "Mustermann" },
+                Status = Status.ACTIVE,
+                TennisClubId = new TennisClubId { Id = Guid.Parse("148c8967-e1fb-4e43-a4a9-8a4e33e2c2ce") }
+            }
+        };
+
+        // When
+        await TestReadEventRepository.AppendEvent(givenEvent);
+        await TestReadEventRepository.Update();
+
+        // Then
+        var baseEvent = await TestReadEventRepository.GetEventById(givenEvent.EventId);
+        Assert.That(baseEvent, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseEvent!.EntityId, Is.EqualTo(Guid.Parse("481241b5-7435-4019-bb6d-e5bf3af4a376")));
+            Assert.That(baseEvent.EntityType, Is.EqualTo(EntityType.MEMBER));
+            Assert.That(baseEvent.EventId, Is.EqualTo(Guid.Parse("73b9f922-ea88-4764-9f0f-7cf132336866")));
+            Assert.That(baseEvent.EventType, Is.EqualTo(EventType.MEMBER_REGISTERED));
+            Assert.That(baseEvent.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Seconds);
+        });
+    }
+}

--- a/PlayOfferService.Tests/IntegrationTests/WriteEventRepositoryTest.cs
+++ b/PlayOfferService.Tests/IntegrationTests/WriteEventRepositoryTest.cs
@@ -56,6 +56,36 @@ public class WriteEventRepositoryTest : TestSetup
             Assert.That(eventData.ProposedEndTime, Is.EqualTo(DateTime.UtcNow.AddHours(3)).Within(1).Seconds);
         });
     }
+    
+    [Test]
+    public async Task GetExistingEventByEntityIdTest()
+    {
+        // Given
+        var entityId = Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60");
+
+        // When
+        var baseEvents = await TestWriteEventRepository.GetEventByEntityId(entityId);
+
+        // Then
+        Assert.That(baseEvents, Has.Count.EqualTo(1));
+        var baseEvent = baseEvents.First();
+        
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseEvent!.EntityId, Is.EqualTo(Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60")));
+            Assert.That(baseEvent.EntityType, Is.EqualTo(EntityType.PLAYOFFER));
+            Assert.That(baseEvent.EventId, Is.EqualTo(Guid.Parse("3b84c030-5d1e-462e-8989-a8bb1407a41c")));
+            Assert.That(baseEvent.EventType, Is.EqualTo(EventType.PLAYOFFER_CREATED));
+            Assert.That(baseEvent.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Seconds);
+            Assert.That(baseEvent.EventData, Is.TypeOf<PlayOfferCreatedEvent>());
+            var eventData = baseEvent.EventData as PlayOfferCreatedEvent;
+            Assert.That(eventData!.Id, Is.EqualTo(Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60")));
+            Assert.That(eventData.ClubId, Is.EqualTo(Guid.Parse("b5aa9ecc-09a8-49ec-8d98-305b9a3ff772")));
+            Assert.That(eventData.CreatorId, Is.EqualTo(Guid.Parse("be7cb6a5-612f-4aa3-9f6e-2c25d812ed49")));
+            Assert.That(eventData.ProposedStartTime, Is.EqualTo(DateTime.UtcNow.AddHours(1)).Within(1).Seconds);
+            Assert.That(eventData.ProposedEndTime, Is.EqualTo(DateTime.UtcNow.AddHours(3)).Within(1).Seconds);
+        });
+    }
 
     [Test]
     public async Task GetNonExistingEventByIdTest()

--- a/PlayOfferService.Tests/IntegrationTests/WriteEventRepositoryTest.cs
+++ b/PlayOfferService.Tests/IntegrationTests/WriteEventRepositoryTest.cs
@@ -1,0 +1,110 @@
+using PlayOfferService.Domain.Events;
+using PlayOfferService.Domain.Events.PlayOffer;
+
+namespace PlayOfferService.Tests.IntegrationTests;
+
+public class WriteEventRepositoryTest : TestSetup
+{
+    [SetUp]
+    public async Task WriteEventSetup()
+    {
+        var existingEvent = new BaseEvent
+        {
+            EntityId = Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60"),
+            EntityType = EntityType.PLAYOFFER,
+            EventId = Guid.Parse("3b84c030-5d1e-462e-8989-a8bb1407a41c"),
+            EventType = EventType.PLAYOFFER_CREATED,
+            Timestamp = DateTime.UtcNow,
+            EventData = new PlayOfferCreatedEvent
+            {
+                Id = Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60"),
+                ClubId = Guid.Parse("b5aa9ecc-09a8-49ec-8d98-305b9a3ff772"),
+                CreatorId = Guid.Parse("be7cb6a5-612f-4aa3-9f6e-2c25d812ed49"),
+                ProposedStartTime = DateTime.UtcNow.AddHours(1),
+                ProposedEndTime = DateTime.UtcNow.AddHours(3)
+            }
+        };
+        
+        await TestWriteEventRepository.AppendEvent(existingEvent);
+        await TestWriteEventRepository.Update();
+    }
+    
+    [Test]
+    public async Task GetExistingEventByIdTest()
+    {
+        // Given
+        var eventId = Guid.Parse("3b84c030-5d1e-462e-8989-a8bb1407a41c");
+
+        // When
+        var baseEvent = await TestWriteEventRepository.GetEventById(eventId);
+
+        // Then
+        Assert.That(baseEvent, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseEvent!.EntityId, Is.EqualTo(Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60")));
+            Assert.That(baseEvent.EntityType, Is.EqualTo(EntityType.PLAYOFFER));
+            Assert.That(baseEvent.EventId, Is.EqualTo(Guid.Parse("3b84c030-5d1e-462e-8989-a8bb1407a41c")));
+            Assert.That(baseEvent.EventType, Is.EqualTo(EventType.PLAYOFFER_CREATED));
+            Assert.That(baseEvent.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Seconds);
+            Assert.That(baseEvent.EventData, Is.TypeOf<PlayOfferCreatedEvent>());
+            var eventData = baseEvent.EventData as PlayOfferCreatedEvent;
+            Assert.That(eventData!.Id, Is.EqualTo(Guid.Parse("e77304ae-421f-445c-a0e6-bfee24e6ba60")));
+            Assert.That(eventData.ClubId, Is.EqualTo(Guid.Parse("b5aa9ecc-09a8-49ec-8d98-305b9a3ff772")));
+            Assert.That(eventData.CreatorId, Is.EqualTo(Guid.Parse("be7cb6a5-612f-4aa3-9f6e-2c25d812ed49")));
+            Assert.That(eventData.ProposedStartTime, Is.EqualTo(DateTime.UtcNow.AddHours(1)).Within(1).Seconds);
+            Assert.That(eventData.ProposedEndTime, Is.EqualTo(DateTime.UtcNow.AddHours(3)).Within(1).Seconds);
+        });
+    }
+
+    [Test]
+    public async Task GetNonExistingEventByIdTest()
+    {
+        // Given
+        var eventId = Guid.Parse("00000000-0000-0000-0000-000000000000");
+
+        // When
+        var baseEvent = await TestWriteEventRepository.GetEventById(eventId);
+
+        // Then
+        Assert.That(baseEvent, Is.Null);
+    }
+
+    [Test]
+    public async Task AppendEventTest()
+    {
+        // Given
+        var givenEvent = new BaseEvent
+        {
+            EntityId = Guid.Parse("8bd27cfb-f84d-41e7-8738-901e27b97555"),
+            EntityType = EntityType.PLAYOFFER,
+            EventId = Guid.Parse("94dfa918-80f3-4dd7-9cb1-78ec4c71ce2e"),
+            EventType = EventType.PLAYOFFER_CREATED,
+            Timestamp = DateTime.UtcNow,
+            EventData = new PlayOfferCreatedEvent
+            {
+                Id = Guid.Parse("8bd27cfb-f84d-41e7-8738-901e27b97555"),
+                ClubId = Guid.Parse("09b884f1-9fbb-4d39-b3a0-a8f676bc00e3"),
+                CreatorId = Guid.Parse("cd03259c-e584-46d1-b79c-3dd25ac4ed93"),
+                ProposedStartTime = DateTime.UtcNow.AddHours(1),
+                ProposedEndTime = DateTime.UtcNow.AddHours(3)
+            }
+        };
+
+        // When
+        await TestWriteEventRepository.AppendEvent(givenEvent);
+        await TestWriteEventRepository.Update();
+
+        // Then
+        var baseEvent = await TestWriteEventRepository.GetEventById(givenEvent.EventId);
+        Assert.That(baseEvent, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseEvent!.EntityId, Is.EqualTo(Guid.Parse("8bd27cfb-f84d-41e7-8738-901e27b97555")));
+            Assert.That(baseEvent.EntityType, Is.EqualTo(EntityType.PLAYOFFER));
+            Assert.That(baseEvent.EventId, Is.EqualTo(Guid.Parse("94dfa918-80f3-4dd7-9cb1-78ec4c71ce2e")));
+            Assert.That(baseEvent.EventType, Is.EqualTo(EventType.PLAYOFFER_CREATED));
+            Assert.That(baseEvent.Timestamp, Is.EqualTo(DateTime.UtcNow).Within(1).Seconds);
+        });
+    }
+}

--- a/PlayOfferService.Tests/TestSetup.cs
+++ b/PlayOfferService.Tests/TestSetup.cs
@@ -18,6 +18,8 @@ public class TestSetup
     protected PlayOfferRepository TestPlayOfferRepository;
     protected ReservationRepository TestReservationRepository;
     protected CourtRepository TestCourtRepository;
+    protected ReadEventRepository TestReadEventRepository;
+    protected WriteEventRepository TestWriteEventRepository;
     protected IMediator Mediator;
     
     [SetUp]
@@ -69,6 +71,12 @@ public class TestSetup
         
         TestCourtRepository = scope.ServiceProvider.GetService<CourtRepository>() ??
                               throw new Exception("Could not get CourtRepository");
+        
+        TestReadEventRepository = scope.ServiceProvider.GetService<ReadEventRepository>() ??
+                                  throw new Exception("Could not get ReadEventRepository");
+        
+        TestWriteEventRepository = scope.ServiceProvider.GetService<WriteEventRepository>() ??
+                                   throw new Exception("Could not get WriteEventRepository");
         
         Mediator = scope.ServiceProvider.GetService<IMediator>() ??
                    throw new Exception("Could not get IMediator");

--- a/Program.cs
+++ b/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddScoped<PlayOfferRepository>();
 builder.Services.AddScoped<ReservationRepository>();
 builder.Services.AddScoped<CourtRepository>();
 builder.Services.AddScoped<ReadEventRepository>();
+builder.Services.AddScoped<WriteEventRepository>();
 builder.Services.AddControllers();
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(Program).Assembly));
 


### PR DESCRIPTION
- Added WriteEventRepository --> Refactored direct DBWriteContext usages to repo
- Added Integrationtests for ReadEventRepository & WriteEventRepository
- Implemented PlayOfferCancelledEvent creation for all PlayOffers of Club/Member who got locked/deleted
- Added GetEventsByEntityId in WriteEventRepository --> Needed for changes in integration tests below
- Adjusted Club/Member EventHandlerTests to check if all PlayOffers got canceled on locked/deleted event